### PR TITLE
web: add WebXR teleoperation with VR controllers

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
       #status { margin-top: 8px; white-space: pre; font-family: monospace; font-size: 11px; }
       #help { font-size: 10px; margin: 4px 0; }
       button { margin-right: 6px; }
+      #calibration-label { display: block; font-size: 11px; margin: 4px 0; }
     </style>
   </head>
   <body>
@@ -44,6 +45,13 @@
       <details open>
         <summary>key bindings</summary>
         <pre id="help"></pre>
+      </details>
+      <details>
+        <summary>WebXR</summary>
+        <label id="calibration-label">
+          <input type="checkbox" id="calibration" />
+          neck pivot calibration (hold Y in the session)
+        </label>
       </details>
       <div id="status">loading…</div>
     </div>
@@ -64,6 +72,8 @@
               "three": `https://cdn.jsdelivr.net/npm/three@${v("three")}/build/three.module.js`,
               "three/examples/jsm/controls/OrbitControls.js":
                 `https://cdn.jsdelivr.net/npm/three@${v("three")}/examples/jsm/controls/OrbitControls.js`,
+              "three/examples/jsm/webxr/VRButton.js":
+                `https://cdn.jsdelivr.net/npm/three@${v("three")}/examples/jsm/webxr/VRButton.js`,
               "@mujoco/mujoco":
                 `https://cdn.jsdelivr.net/npm/@mujoco/mujoco@${v("@mujoco/mujoco")}/mujoco.js`,
             },

--- a/web/README.md
+++ b/web/README.md
@@ -64,11 +64,74 @@ solution of that pose.
 | +Roll / -Roll | T / B | P / / |
 | Gripper close / open | G / V | ; / . |
 
+## WebXR (VR controllers)
+
+The page also runs as a WebXR session: open it in the browser of a
+headset such as Meta Quest 3 or PICO 4 and press **ENTER VR** at the
+bottom of the page. The MuJoCo world is drawn around the operator,
+turned y-up for the headset, and the arms follow the controllers: the
+trigger closes the gripper, turning the head moves neither the world
+nor the targets, the **X** button resets the environment (like the
+Reset button and Backspace) and the **B** button leaves the session. A text panel
+below the view shows the status lines.
+
+The headset starts where the robot's head would be: OpenArm has none,
+so `HEAD_OFFSET` in `xr-pose.js` puts the eyes a human 22 cm above (and
+3 cm ahead of) the `arm_origin` site between the shoulder joints, in
+every scene. The arms hang below the operator like their own.
+
+The processing that
+[dora-openarm-webxr](https://github.com/enactic/dora-openarm-webxr) does
+in its Python node runs in the browser here, as direct ports of that
+project's sources:
+
+| Module           | Ported from                    | What it does |
+|------------------|--------------------------------|--------------|
+| `xr-frame.js`    | `static/ar.js`                 | reads the headset pose, the controllers' target-ray poses, triggers, squeezes, thumbsticks and A/B/X/Y buttons out of an `XRFrame` into the frame object the dora client sends. |
+| `xr-pose.js`     | `main.py`, `smoothing.py`      | converts a controller pose into an `arm_origin`-frame target (WebXR to robot axes, neck pivot subtraction, aim pose to gripper turn, frame offset), smooths it with the same One Euro filter, and writes it into `TeleopState` for the IK. |
+| `calibration.js` | `calibration.py`, `main.py`    | the neck pivot calibration: the least-squares fit of the point the head turns about, and the checks that accept or reject a run. |
+
+The constants (`ROBOT_ROTATION`, the frame offset `[-0.085, 0, -0.14]`,
+the neck pivot estimate `[0, -0.075, 0.08]`, the filter parameters) are
+the node's defaults. Nothing goes over the network: there is no dora
+node, no WebRTC and no camera panel, since the simulation itself is what
+the operator sees.
+
+**Neck pivot calibration.** Tick *neck pivot calibration* under
+**WebXR** in the panel before entering VR, then hold the **Y** button (left controller), keep the body
+still, turn the head side to side twice and up and down twice, and
+release. The hands stop following while Y is held. The result (or the
+reason a run was rejected, and what to do differently) appears on the
+panel in the headset and in the browser console. An accepted offset is
+kept in the browser's `localStorage`, so it survives reloads; the box
+only says whether the Y button measures, and only from the next session
+on.
+
+**HTTPS.** WebXR only runs on a secure page. The GitHub Pages deployment
+is one; a page served from `localhost` is too (that is how the
+[Immersive Web
+Emulator](https://chromewebstore.google.com/detail/immersive-web-emulator/cgffilbpcibhmcfbgggfhfolhkfbhmik)
+can drive it on a desktop Chrome without a headset). A headset on the
+LAN needs TLS, so `serve.mjs` serves HTTPS when it is given a
+certificate, with the same variables dora-openarm-webxr uses. A
+self-signed one is enough (the headset browser shows a warning to step
+through under "Advanced"):
+
+```sh
+name=$(hostname).local  # a name the headset can resolve
+openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+  -subj "/CN=${name}" -addext "subjectAltName=DNS:${name}" \
+  -keyout server.key -out server.crt
+TLS_CERTIFICATE_FILE=server.crt TLS_KEY_FILE=server.key npm run serve
+# then open https://${name}:8080/ in the headset
+```
+
 ## Tests
 
 ```sh
 npm test              # node:test-based headless tests: IK convergence,
-                      # teleop semantics, and every scene loading
+                      # teleop semantics, every scene loading, and the
+                      # WebXR pipeline (pose mapping, smoothing, calibration)
 npm run test:browser  # Playwright end-to-end test (starts serve.mjs itself);
                       # first run: npx playwright install chromium
 ```

--- a/web/browser.spec.mjs
+++ b/web/browser.spec.mjs
@@ -121,6 +121,110 @@ test("the lifter carries the arms up, Backspace resets it", async () => {
   await settle();
 });
 
+test("the WebXR button is offered, and says why it cannot start here", async () => {
+  // Headless Chromium has no headset: three's VRButton reports that instead
+  // of an "ENTER VR" button.
+  const button = page.locator("body > button", {
+    hasText: /VR NOT SUPPORTED|VR NOT ALLOWED|WEBXR NEEDS HTTPS|ENTER VR/,
+  });
+  await expect(button).toHaveCount(1);
+});
+
+test("controller frames drive the arms through the same pipeline", async () => {
+  // No headset in the test browser, so the session is stood up by hand
+  // (onSessionStart is what the renderer calls) and frames are fed straight
+  // to applyXRFrame, which is where readFrame's output would go.
+  await page.keyboard.press("Backspace"); // the previous test left R's target
+  await settle();
+  const before = await rightEE();
+  const beforeLeft = await leftEE();
+  const moved = await page.evaluate(async () => {
+    const { robotPoseToXR } = await import("/web/xr-pose.js");
+    const THREE = await import("three");
+    const app = window.__app;
+    app.onSessionStart();
+    const identity = { x: 0, y: 0, z: 0, qx: 0, qy: 0, qz: 0, qw: 1 };
+    // right hand 5 cm ahead of its home target, left hand at home, both in
+    // the home orientation
+    const hand = (side, dx) => {
+      const { homePos, homeQuat } = app.teleop.arms[side];
+      const pos = [homePos[0] + dx, homePos[1], homePos[2]];
+      return robotPoseToXR(pos, homeQuat, identity, app.xrTeleop);
+    };
+    const frame = {
+      pose_reference: identity,
+      pose_right: hand("right", 0.05),
+      pose_left: hand("left", 0),
+      trigger_right: 0.4,
+      trigger_left: 0,
+    };
+    // a second of frames: the One Euro filter has settled by then
+    for (let i = 0; i < 72; i++) app.applyXRFrame(frame, i / 72);
+    // where the robot's head position (HEAD_OFFSET above arm_origin) ended
+    // up in the headset's space
+    const { HEAD_OFFSET } = await import("/web/xr-pose.js");
+    const origin = app.controller.originPose(app.mjData);
+    const camera = new THREE.Vector3(...origin.pos).add(
+      new THREE.Vector3(...HEAD_OFFSET),
+    );
+    app.world.updateMatrixWorld(true);
+    app.world.localToWorld(camera);
+    return {
+      target: [...app.teleop.arms.right.pos],
+      grip: app.teleop.arms.right.grip,
+      placed: app.xrPlaced,
+      worldUp: app.world.quaternion.toArray(),
+      camera: camera.toArray(),
+    };
+  });
+  expect(moved.placed).toBe(true);
+  expect(moved.grip).toBeCloseTo(0.4);
+  expect(moved.worldUp).not.toEqual([0, 0, 0, 1]); // turned y-up for the headset
+  // the head position is drawn at the headset (identity pose here)
+  expect(Math.hypot(...moved.camera)).toBeLessThan(1e-3); // lifter sag
+  await expect
+    .poll(async () => (await rightEE())[0], { timeout: 20_000 })
+    .toBeGreaterThan(before[0] + 0.03);
+  await settle();
+  const after = await rightEE();
+  expect(after[0] - before[0]).toBeCloseTo(0.05, 2);
+  expect(Math.abs(after[1] - before[1])).toBeLessThan(0.01);
+  expect(Math.abs(after[2] - before[2])).toBeLessThan(0.01);
+  const afterLeft = await leftEE();
+  expect(
+    Math.hypot(...afterLeft.map((v, i) => v - beforeLeft[i])),
+  ).toBeLessThan(0.01);
+  // X resets the environment once per press, B ends the session
+  const presses = await page.evaluate(() => {
+    const app = window.__app;
+    const calls = { reset: 0, end: 0 };
+    app.reset = () => {
+      calls.reset++;
+    };
+    app.endSession = () => {
+      calls.end++;
+    };
+    const identity = { x: 0, y: 0, z: 0, qx: 0, qy: 0, qz: 0, qw: 1 };
+    let t = 2;
+    for (const button_x of [true, true, false, true, false]) {
+      app.applyXRFrame({ pose_reference: identity, button_x }, t++);
+    }
+    app.applyXRFrame({ pose_reference: identity, button_b: true }, t++);
+    delete app.reset;
+    delete app.endSession;
+    return calls;
+  });
+  expect(presses).toEqual({ reset: 2, end: 1 });
+  // ending the session puts the world back and keeps the last pose
+  await page.evaluate(() => window.__app.onSessionEnd());
+  expect(
+    await page.evaluate(() => window.__app.world.quaternion.toArray()),
+  ).toEqual([0, 0, 0, 1]);
+  expect(await page.evaluate(() => window.__app.xrTeleop)).toBeNull();
+  await page.keyboard.press("Backspace");
+  await settle();
+});
+
 test("teleop still works after switching scenes", async () => {
   await page.selectOption("#scene-select", "pedestal/bottle_scene.xml");
   await page.waitForFunction(

--- a/web/calibration.js
+++ b/web/calibration.js
@@ -1,0 +1,328 @@
+// Copyright 2026 Enactic, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Neck pivot calibration, ported from dora-openarm-webxr
+// (src/dora_openarm_webxr/calibration.py, and the run collection and the
+// accept-or-reject policy of main.py).
+//
+// The hand targets are made relative to a point in the operator's neck
+// rather than the headset itself, because the headset orbits that point as
+// the head turns. The offset from the headset to it is an estimate that
+// anatomy varies, so this measures it: hold the body still, hold the Y
+// button, turn the head, and the one point that stays put through the turn
+// is the pivot.
+import { quatToMat } from "./ik.js";
+
+// How many headset poses a run may hold. A button left held down stops
+// growing here instead of the page's memory; at the headset's display rate
+// this is some twenty seconds, well past any deliberate shake.
+const CAPACITY = 2000;
+
+// Fewer poses than this and the run is too thin to fit from: a second or
+// so of holding, which catches the operator who lets the button go before
+// turning their head at all.
+const MIN_SAMPLES = 100;
+
+// A run has to turn the head far enough about every axis for the fit to
+// see all three offset components. 0.02 is about a 20 degree sweep, which a
+// deliberate shake passes twice over.
+const MIN_OBSERVABILITY = 0.02;
+
+// The headset's own axes, in the order the offset components come in, and
+// the head motion that pins each of them: a rotation cannot see the offset
+// along the axis it turns about, so only yawing hides the vertical offset
+// and only nodding hides the lateral one.
+const OFFSET_AXIS_NAMES = ["lateral", "vertical", "fore-aft"];
+const PINNING_MOTION = ["side to side", "up and down", "side to side"];
+
+// How far the fitted pivot may still wander over the run, in meters. Body
+// motion lands here, and so does the model error (a neck yaws and nods
+// about joints a few centimeters apart rather than one point).
+const MAX_RESIDUAL = 0.02;
+
+// Where a neck can be, relative to the eyes, in meters: on the midline, and
+// below and behind them.
+const MAX_LATERAL = 0.05;
+const MAX_VERTICAL = 0.2;
+const MAX_FORE_AFT = 0.2;
+
+// Eigendecomposition of a symmetric 3x3 matrix (row-major, 9 numbers) by
+// cyclic Jacobi rotations. Returns the eigenvalues ascending and the
+// matching unit eigenvectors as rows.
+export function symmetricEigen3(matrix) {
+  const a = [...matrix];
+  const v = [1, 0, 0, 0, 1, 0, 0, 0, 1];
+  for (let sweep = 0; sweep < 50; sweep++) {
+    const off = Math.hypot(a[1], a[2], a[5]);
+    if (off < 1e-15 * Math.max(1, Math.hypot(a[0], a[4], a[8]))) break;
+    for (const [p, q] of [
+      [0, 1],
+      [0, 2],
+      [1, 2],
+    ]) {
+      const apq = a[p * 3 + q];
+      if (apq === 0) continue;
+      const app = a[p * 3 + p];
+      const aqq = a[q * 3 + q];
+      const theta = (aqq - app) / (2 * apq);
+      const t =
+        Math.sign(theta || 1) /
+        (Math.abs(theta) + Math.sqrt(theta * theta + 1));
+      const c = 1 / Math.sqrt(t * t + 1);
+      const s = t * c;
+      for (let k = 0; k < 3; k++) {
+        // rotate columns p and q of a (and rows, by symmetry)
+        const akp = a[k * 3 + p];
+        const akq = a[k * 3 + q];
+        a[k * 3 + p] = c * akp - s * akq;
+        a[k * 3 + q] = s * akp + c * akq;
+      }
+      for (let k = 0; k < 3; k++) {
+        const apk = a[p * 3 + k];
+        const aqk = a[q * 3 + k];
+        a[p * 3 + k] = c * apk - s * aqk;
+        a[q * 3 + k] = s * apk + c * aqk;
+      }
+      for (let k = 0; k < 3; k++) {
+        const vkp = v[k * 3 + p];
+        const vkq = v[k * 3 + q];
+        v[k * 3 + p] = c * vkp - s * vkq;
+        v[k * 3 + q] = s * vkp + c * vkq;
+      }
+    }
+  }
+  const order = [0, 1, 2].sort((i, j) => a[i * 3 + i] - a[j * 3 + j]);
+  return {
+    values: order.map((i) => a[i * 3 + i]),
+    vectors: order.map((i) => [v[i], v[3 + i], v[6 + i]]),
+  };
+}
+
+function mean3(points) {
+  const m = [0, 0, 0];
+  for (const p of points) for (let i = 0; i < 3; i++) m[i] += p[i];
+  return m.map((v) => v / points.length);
+}
+
+// RMS distance of points from their own mean, in meters.
+function rmsSpread(points) {
+  const m = mean3(points);
+  let sum = 0;
+  for (const p of points) {
+    sum += (p[0] - m[0]) ** 2 + (p[1] - m[1]) ** 2 + (p[2] - m[2]) ** 2;
+  }
+  return Math.sqrt(sum / points.length);
+}
+
+// Fit the headset-to-neck-pivot offset from a run of headset poses
+// (calibration.py: fit_pivot_offset).
+//
+// The pivot in world coordinates is p + R * offset for a headset at
+// position p with rotation R. It is the point that does not move while the
+// head turns, so the offset that makes those points agree best across the
+// run is the fit: minimise sum |(p_i - mean p) + (R_i - mean R) offset|^2,
+// a 3x3 linear least squares. Writing A_i = R_i - mean R and b_i = p_i -
+// mean p, the normal equations are (sum A_i^T A_i) offset = -sum A_i^T b_i.
+//
+// `positions` are [x, y, z] and `quats` are [w, x, y, z], both in the same
+// world-fixed frame. Returns { offset, diagnostics } where the diagnostics
+// hold what the caller needs to judge the fit, never a verdict:
+//   samples: how many poses went in.
+//   residualRms: how far the fitted pivot still moves, in meters.
+//   headsetRms: the same spread for the headset itself, which is what
+//     subtracting the headset alone would have carried into the target.
+//   observability: the eigenvalues of the normal matrix, averaged over the
+//     run and ascending. Each says how much pivot motion a unit of offset
+//     along its own axis would have produced.
+//   observabilityAxes: the matching unit eigenvectors, in the headset's
+//     own frame.
+// A direction the head never turned about comes back as zero rather than
+// as a division by a rounding error.
+export function fitPivotOffset(positions, quats) {
+  const samples = positions.length;
+  const matrices = quats.map(quatToMat);
+  const meanMatrix = new Array(9).fill(0);
+  for (const m of matrices) for (let i = 0; i < 9; i++) meanMatrix[i] += m[i];
+  for (let i = 0; i < 9; i++) meanMatrix[i] /= samples;
+  const meanPosition = mean3(positions);
+
+  // normal = sum A_i^T A_i / N, right = -sum A_i^T b_i / N; averaged over
+  // the run so thresholds do not move with how long the operator shook.
+  const normal = new Array(9).fill(0);
+  const right = [0, 0, 0];
+  for (let n = 0; n < samples; n++) {
+    const A = matrices[n].map((v, i) => v - meanMatrix[i]);
+    const b = positions[n].map((v, i) => v - meanPosition[i]);
+    for (let j = 0; j < 3; j++) {
+      for (let k = 0; k < 3; k++) {
+        let s = 0;
+        for (let i = 0; i < 3; i++) s += A[i * 3 + j] * A[i * 3 + k];
+        normal[j * 3 + k] += s;
+      }
+      let s = 0;
+      for (let i = 0; i < 3; i++) s += A[i * 3 + j] * b[i];
+      right[j] -= s;
+    }
+  }
+  for (let i = 0; i < 9; i++) normal[i] /= samples;
+  for (let i = 0; i < 3; i++) right[i] /= samples;
+
+  // Symmetric and positive semi-definite by construction, and its
+  // eigenvalues are exactly the per-direction observability.
+  const { values, vectors } = symmetricEigen3(normal);
+  const largest = values[2];
+  const offset = [0, 0, 0];
+  for (let k = 0; k < 3; k++) {
+    if (!(values[k] > largest * 1e-12)) continue;
+    const axis = vectors[k];
+    const projected =
+      (axis[0] * right[0] + axis[1] * right[1] + axis[2] * right[2]) /
+      values[k];
+    for (let i = 0; i < 3; i++) offset[i] += axis[i] * projected;
+  }
+
+  const pivots = positions.map((p, n) => {
+    const m = matrices[n];
+    return [
+      p[0] + m[0] * offset[0] + m[1] * offset[1] + m[2] * offset[2],
+      p[1] + m[3] * offset[0] + m[4] * offset[1] + m[5] * offset[2],
+      p[2] + m[6] * offset[0] + m[7] * offset[1] + m[8] * offset[2],
+    ];
+  });
+
+  return {
+    offset,
+    diagnostics: {
+      samples,
+      residualRms: rmsSpread(pivots),
+      headsetRms: rmsSpread(positions),
+      observability: values,
+      observabilityAxes: vectors,
+    },
+  };
+}
+
+// Why a fitted neck pivot offset is not worth applying, or null
+// (main.py: _check_pivot_offset).
+export function checkPivotOffset(offset, diagnostics) {
+  const { samples, observability, observabilityAxes, residualRms } =
+    diagnostics;
+  if (samples < MIN_SAMPLES) {
+    return (
+      `only ${samples} headset poses came in; ` +
+      "hold Y down for the whole head turn, not just a tap"
+    );
+  }
+  if (observability[0] < MIN_OBSERVABILITY) {
+    const weakest = observabilityAxes[0].map(Math.abs);
+    const axis = weakest.indexOf(Math.max(...weakest));
+    return (
+      `the head did not turn enough to see the ${OFFSET_AXIS_NAMES[axis]} ` +
+      `offset; turn it ${PINNING_MOTION[axis]} as well`
+    );
+  }
+  if (residualRms > MAX_RESIDUAL) {
+    return (
+      `the pivot still moved ${(residualRms * 1000).toFixed(0)} mm over ` +
+      "the run; hold the body still and turn only the head"
+    );
+  }
+  const [lateral, vertical, foreAft] = offset;
+  if (
+    Math.abs(lateral) > MAX_LATERAL ||
+    !(-MAX_VERTICAL <= vertical && vertical <= 0) ||
+    !(0 <= foreAft && foreAft <= MAX_FORE_AFT)
+  ) {
+    const formatted = offset.map((v) => v.toFixed(3)).join(", ");
+    return (
+      `the fitted offset [${formatted}] is not where a neck is: it belongs ` +
+      "on the midline, below the eyes and behind them"
+    );
+  }
+  return null;
+}
+
+// Fit a run and judge it (main.py: _apply_pivot_calibration, minus the
+// side effects). Returns { accepted: true, offset, samples, residualMm,
+// headsetMm } or { accepted: false, reason }.
+export function calibratePivot(samples) {
+  const { offset, diagnostics } = fitPivotOffset(
+    samples.map((s) => s.pos),
+    samples.map((s) => s.quat),
+  );
+  const reason = checkPivotOffset(offset, diagnostics);
+  if (reason !== null) return { accepted: false, reason };
+  return {
+    accepted: true,
+    offset,
+    samples: diagnostics.samples,
+    residualMm: diagnostics.residualRms * 1000,
+    headsetMm: diagnostics.headsetRms * 1000,
+  };
+}
+
+// Collects headset poses while the operator holds the Y button down
+// (main.py: _PivotCalibration).
+//
+// The button state arrives once per frame rather than as press and release
+// events, so the edges are found here. Reading it that way is also the
+// failsafe: a controller that falls asleep mid-run stops reporting the
+// button at all, the caller reads that as not pressed, and the run ends
+// instead of leaving the hands stopped for good.
+//
+// A disabled one keeps no poses and never stops the hands: measuring is a
+// thing the operator sets out to do, not something a press can start by
+// accident.
+export class PivotCalibration {
+  constructor({ enabled = false, capacity = CAPACITY } = {}) {
+    this.enabled = enabled;
+    this.capacity = capacity;
+    this.running = false;
+    this.samples = [];
+  }
+
+  // Whether a run is under way, so poses belong to it.
+  get collecting() {
+    return this.running;
+  }
+
+  // Take the button state for a frame. The press is the run: it starts the
+  // frame the button goes down and ends the frame it comes up, when the
+  // run's samples are returned for fitting; null otherwise.
+  update(pressed) {
+    if (!this.enabled) return null;
+    if (pressed) {
+      if (!this.running) {
+        this.running = true;
+        this.samples = [];
+      }
+      return null;
+    }
+    const running = this.running;
+    this.running = false;
+    if (!running || this.samples.length === 0) return null;
+    return this.samples;
+  }
+
+  // Keep a headset pose (WebXR {x, y, z, qx, qy, qz, qw}) if a run is under
+  // way, otherwise drop it.
+  add(reference) {
+    if (!this.collecting) return;
+    if (this.samples.length >= this.capacity) this.samples.shift();
+    this.samples.push({
+      pos: [reference.x, reference.y, reference.z],
+      quat: [reference.qw, reference.qx, reference.qy, reference.qz],
+    });
+  }
+}

--- a/web/ik.js
+++ b/web/ik.js
@@ -18,7 +18,7 @@
 // solve() runs damped-least-squares IK there and returns exact joint targets
 // for a requested end-effector pose, without touching the simulation state.
 
-function mat2quat(m) {
+export function mat2quat(m) {
   const q = [0, 0, 0, 0];
   const tr = m[0] + m[4] + m[8];
   if (tr > 0) {
@@ -58,11 +58,11 @@ export function quatMul(a, b) {
   ];
 }
 
-function quatConj(q) {
+export function quatConj(q) {
   return [q[0], -q[1], -q[2], -q[3]];
 }
 
-function quatRotVec(q, v) {
+export function quatRotVec(q, v) {
   const [w, x, y, z] = q;
   const [vx, vy, vz] = v;
   // t = 2 q_vec x v; v' = v + w t + q_vec x t
@@ -73,6 +73,22 @@ function quatRotVec(q, v) {
     vx + w * tx + y * tz - z * ty,
     vy + w * ty + z * tx - x * tz,
     vz + w * tz + x * ty - y * tx,
+  ];
+}
+
+// Rotation matrix (row-major 3x3) of a unit quaternion; inverse of mat2quat.
+export function quatToMat(q) {
+  const [w, x, y, z] = q;
+  return [
+    1 - 2 * (y * y + z * z),
+    2 * (x * y - w * z),
+    2 * (x * z + w * y),
+    2 * (x * y + w * z),
+    1 - 2 * (x * x + z * z),
+    2 * (y * z - w * x),
+    2 * (x * z - w * y),
+    2 * (y * z + w * x),
+    1 - 2 * (x * x + y * y),
   ];
 }
 
@@ -87,7 +103,7 @@ export function poseLocalToWorld(origin, pos, quat) {
 }
 
 // Inverse of poseLocalToWorld.
-function poseWorldToLocal(origin, pos, quat) {
+export function poseWorldToLocal(origin, pos, quat) {
   const inv = quatConj(origin.quat);
   return {
     pos: quatRotVec(inv, [

--- a/web/main.js
+++ b/web/main.js
@@ -24,8 +24,16 @@ import loadMuJoCo from "@mujoco/mujoco";
 // The pose targets come from TeleopState (teleop.js), which integrates held
 // keys exactly like dora-openarm-keyboard: hold to move, tool-frame rotation,
 // +/- speed scaling, Backspace to return home.
+//
+// In a WebXR session the targets come from the VR controllers instead:
+// xr-frame.js reads each frame the way dora-openarm-webxr's client does, and
+// XRTeleop (xr-pose.js, a port of that project's Python node) converts the
+// controller poses into arm_origin-frame targets and writes them into the
+// same TeleopState. The MuJoCo world is placed in the headset's reference
+// space so that the virtual grippers coincide with the controllers.
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
+import { VRButton } from "three/examples/jsm/webxr/VRButton.js";
 import { PoseController } from "./ik.js";
 import {
   HELP_TEXT,
@@ -36,6 +44,14 @@ import {
 } from "./keymap.js";
 import { buildVFS } from "./model-vfs.js";
 import { TeleopState } from "./teleop.js";
+import { readFrame } from "./xr-frame.js";
+import { XRHud } from "./xr-hud.js";
+import {
+  DEFAULT_NECK_PIVOT_OFFSET,
+  headAnchor,
+  worldPlacement,
+  XRTeleop,
+} from "./xr-pose.js";
 
 let mujoco;
 
@@ -45,6 +61,36 @@ const SIDES = ["left", "right"];
 // directory. The path is resolved against the page URL (index.html at
 // the repository root), so serve the repository root.
 const MODEL_BASE = "v2/";
+
+// A measured neck pivot offset outlives the page (dora-openarm-webxr keeps
+// it in neck_pivot.yaml): the whole point of measuring an operator is
+// keeping the number they measured.
+const NECK_PIVOT_STORAGE_KEY = "openarm-mujoco-web.neck_pivot_offset";
+
+function loadNeckPivotOffset() {
+  try {
+    const stored = JSON.parse(localStorage.getItem(NECK_PIVOT_STORAGE_KEY));
+    if (
+      Array.isArray(stored) &&
+      stored.length === 3 &&
+      stored.every((v) => Number.isFinite(v))
+    ) {
+      return stored;
+    }
+  } catch {
+    // no storage, or a value that is not ours: use the estimate
+  }
+  return DEFAULT_NECK_PIVOT_OFFSET;
+}
+
+function saveNeckPivotOffset(offset) {
+  try {
+    localStorage.setItem(NECK_PIVOT_STORAGE_KEY, JSON.stringify(offset));
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 // fetch() resolves on HTTP errors, so check ok here: a missing model file
 // must fail with its name, not as a later, unrelated MuJoCo parse error on
@@ -171,12 +217,27 @@ class App {
 
     this.scene = new THREE.Scene();
     this.scene.background = new THREE.Color(0x263238);
+    // Everything MuJoCo draws lives in this group, in MuJoCo's z-up world
+    // coordinates. On the desktop it is the identity; in a WebXR session it
+    // is moved so that the arm_origin frame lands where the operator is
+    // (see placeWorld), since WebXR's reference space is y-up and anchored
+    // to the headset.
+    this.world = new THREE.Group();
+    this.scene.add(this.world);
 
     this.renderer = new THREE.WebGLRenderer({ antialias: true });
     this.renderer.setSize(window.innerWidth, window.innerHeight);
     // MuJoCo material rgba is authored for direct display (not Three's sRGB workflow).
     this.renderer.outputColorSpace = THREE.LinearSRGBColorSpace;
     document.body.appendChild(this.renderer.domElement);
+    this.renderer.xr.enabled = true;
+    // "local" like dora-openarm-webxr: the origin is where the headset was
+    // when the session started, which is also what the world is placed from.
+    this.renderer.xr.setReferenceSpaceType("local");
+    this.renderer.xr.addEventListener("sessionstart", () =>
+      this.onSessionStart(),
+    );
+    this.renderer.xr.addEventListener("sessionend", () => this.onSessionEnd());
 
     this.camera = new THREE.PerspectiveCamera(
       45,
@@ -191,6 +252,17 @@ class App {
     this.controls.target.set(0.4, 0, 1.15);
     this.initLights();
 
+    // The headset panel rides on the camera, which WebXR moves with the
+    // head; on the desktop it is hidden.
+    this.scene.add(this.camera);
+    this.hud = new XRHud();
+    this.camera.add(this.hud.mesh);
+    this.calibrationEnabled = false;
+    this.calibrationMessage = null;
+    this.xrTeleop = null; // one per session
+    this.xrPlaced = false;
+    this.xrButtonX = false; // last frame's X, for the press edge
+
     window.addEventListener("resize", () => {
       this.camera.aspect = window.innerWidth / window.innerHeight;
       this.camera.updateProjectionMatrix();
@@ -200,7 +272,7 @@ class App {
 
   disposeScene() {
     for (const mesh of this.meshes) {
-      this.scene.remove(mesh);
+      this.world.remove(mesh);
       mesh.material.dispose();
     }
     this.meshes = [];
@@ -209,7 +281,7 @@ class App {
     for (const texture of this.checkerTextureCache.values()) texture.dispose();
     this.checkerTextureCache.clear();
     if (this.markers) {
-      for (const side of SIDES) this.scene.remove(this.markers[side]);
+      for (const side of SIDES) this.world.remove(this.markers[side]);
       this.markers = null;
     }
     this.mjvScene?.delete();
@@ -232,6 +304,7 @@ class App {
     this.teleop.reset();
     this.lifterHeight = 0;
     this.held.clear();
+    this.xrPlaced = false; // a new scene is placed afresh mid-session
 
     try {
       const vfs = await buildVFS(mujoco, scenePath, fetchModelBytes, DOMParser);
@@ -298,23 +371,122 @@ class App {
   }
 
   initLights() {
+    // In the world group, so they keep lighting the scene from above when
+    // the group is turned y-up for a headset.
     const ambient = new THREE.AmbientLight(0xffffff, 0.6);
-    this.scene.add(ambient);
+    this.world.add(ambient);
     const dir = new THREE.DirectionalLight(0xffffff, 1.2);
     dir.position.set(2, 1, 2);
-    this.scene.add(dir);
+    this.world.add(dir);
     const dir2 = new THREE.DirectionalLight(0xffffff, 0.5);
     dir2.position.set(-2, -1, 1);
-    this.scene.add(dir2);
+    this.world.add(dir2);
   }
 
   initTargetMarkers() {
     this.markers = {};
     for (const side of SIDES) {
       const marker = new THREE.AxesHelper(0.08);
-      this.scene.add(marker);
+      this.world.add(marker);
       this.markers[side] = marker;
     }
+  }
+
+  // --- WebXR ---------------------------------------------------------------
+  onSessionStart() {
+    // Fresh smoothers and calibration per session, like dora-openarm-webxr's
+    // session-start; the measured neck pivot offset is the one thing kept.
+    this.xrTeleop = new XRTeleop({
+      neckPivotOffset: loadNeckPivotOffset(),
+      calibration: this.calibrationEnabled,
+      onCalibrationResult: (result) => this.onCalibrationResult(result),
+    });
+    this.xrPlaced = false;
+    this.xrButtonX = false;
+    this.calibrationMessage = null;
+    this.hud.mesh.visible = true;
+  }
+
+  onSessionEnd() {
+    this.xrTeleop = null;
+    this.xrPlaced = false;
+    this.hud.mesh.visible = false;
+    this.world.position.set(0, 0, 0);
+    this.world.quaternion.identity();
+    // The arms hold the last controller pose; Backspace / Reset return home.
+  }
+
+  onCalibrationResult(result) {
+    if (result.accepted) {
+      const saved = saveNeckPivotOffset(result.offset);
+      const formatted = result.offset.map((v) => v.toFixed(3)).join(", ");
+      this.calibrationMessage =
+        `neck pivot calibration applied from ${result.samples} poses: ` +
+        `the pivot held to ${result.residualMm.toFixed(1)} mm while the ` +
+        `headset moved ${result.headsetMm.toFixed(1)} mm.\n` +
+        `  neck_pivot_offset: [${formatted}]` +
+        (saved ? " (saved in this browser)" : "");
+    } else {
+      this.calibrationMessage = `neck pivot calibration rejected: ${result.reason}`;
+    }
+    console.log(this.calibrationMessage);
+  }
+
+  // Place the MuJoCo world in the headset's reference space, anchored to
+  // the headset pose of the first frame: the headset starts where the
+  // robot's head would be (HEAD_OFFSET above the arm_origin site), so the
+  // arms hang below the operator like their own. A head turn then moves
+  // neither the world nor (thanks to the neck pivot) the targets.
+  placeWorld(reference) {
+    const origin = this.controller.originPose(this.mjData);
+    const { pos, quat } = worldPlacement(
+      origin,
+      reference,
+      this.xrTeleop,
+      headAnchor(origin, reference),
+    );
+    this.world.position.set(pos[0], pos[1], pos[2]);
+    this.world.quaternion.set(quat[1], quat[2], quat[3], quat[0]);
+    this.xrPlaced = true;
+  }
+
+  // Leave the immersive session (the B button); no-op outside one.
+  endSession() {
+    this.renderer.xr.getSession()?.end();
+  }
+
+  // Feed one frame object (xr-frame.js's readFrame, or a test's) at `time`
+  // seconds to the controller pipeline. No-op outside a session.
+  applyXRFrame(response, time) {
+    if (!this.xrTeleop || !this.controller) return;
+    if (!this.xrPlaced && response.pose_reference) {
+      this.placeWorld(response.pose_reference);
+    }
+    this.xrTeleop.processFrame(response, time, this.teleop);
+    // X resets the environment (the Reset button / Backspace), once per
+    // press: the button state comes every frame, so the edge is found here.
+    const x = response.button_x === true;
+    if (x && !this.xrButtonX) this.reset();
+    this.xrButtonX = x;
+    // Like dora-openarm-webxr's --quit-button: a press ends the session.
+    if (response.button_b === true) this.endSession();
+  }
+
+  hudText() {
+    const lines = [];
+    if (this.calibrationEnabled) {
+      const running = this.xrTeleop?.calibration.collecting;
+      lines.push(
+        running
+          ? "CALIBRATING: keep the body still, turn the head side to side " +
+              "and up and down, then release Y"
+          : "neck pivot calibration: hold Y, turn the head, release",
+      );
+    }
+    if (this.calibrationMessage) lines.push(this.calibrationMessage);
+    lines.push(this.lastStatus ?? "");
+    lines.push("X: reset    B: leave VR");
+    return lines.join("\n");
   }
 
   applyTargets() {
@@ -465,10 +637,20 @@ class App {
     }
   }
 
-  update(dt) {
-    this.controls.update();
+  update(dt, now, xrFrame) {
+    // OrbitControls would fight the headset for the camera.
+    if (!this.renderer.xr.isPresenting) this.controls.update();
     if (!this.mjModel) return; // scene is loading
 
+    // Controller poses overwrite the targets; held keys still integrate on
+    // top (the desktop keyboard keeps working alongside a headset).
+    if (xrFrame && this.renderer.xr.isPresenting) {
+      const session = this.renderer.xr.getSession();
+      const space = this.renderer.xr.getReferenceSpace();
+      if (session && space) {
+        this.applyXRFrame(readFrame(session, space, xrFrame), now / 1000);
+      }
+    }
     this.teleop.step(dt, this.held);
 
     this.applyTargets();
@@ -505,7 +687,7 @@ class App {
         });
         mesh = new THREE.Mesh(this.getBufferGeometry(g), material);
         this.meshes.push(mesh);
-        this.scene.add(mesh);
+        this.world.add(mesh);
       }
       mesh.visible = true;
       this.applyGeomAppearance(mesh, g);
@@ -554,31 +736,35 @@ class App {
     // The values are quantized by toFixed, so while settled the text is
     // stable: skip the DOM write (and its style invalidation) entirely.
     const text = lines.join("\n");
-    if (text === this.lastStatus) return;
-    this.lastStatus = text;
-    this.statusElement.textContent = text;
+    if (text !== this.lastStatus) {
+      this.lastStatus = text;
+      this.statusElement.textContent = text;
+    }
+    if (this.hud.mesh.visible) this.hud.setText(this.hudText());
   }
 
   run() {
     let last = null;
-    const animate = (now) => {
-      // requestAnimationFrame pauses in background tabs: clamp dt so that
-      // returning to the tab does not fast-forward all the missed time in
-      // one frame.
+    // The renderer's animation loop, not requestAnimationFrame: inside a
+    // WebXR session frames come from the session, and the renderer hands
+    // the XRFrame along.
+    const animate = (now, xrFrame) => {
+      // The loop pauses in background tabs: clamp dt so that returning to
+      // the tab does not fast-forward all the missed time in one frame.
       const dt = last === null ? 0 : Math.min((now - last) / 1000, 0.1);
       last = now;
       try {
-        this.update(dt);
+        this.update(dt, now, xrFrame);
         this.renderer.render(this.scene, this.camera);
       } catch (e) {
         // Stop the loop and rethrow: a swallowed error would repeat at 60 fps
         // with a frozen scene and would never reach pageerror listeners.
+        this.renderer.setAnimationLoop(null);
         this.statusElement.textContent = `error: ${e.message ?? e}`;
         throw e;
       }
-      requestAnimationFrame(animate);
     };
-    requestAnimationFrame(animate);
+    this.renderer.setAnimationLoop(animate);
   }
 }
 
@@ -656,6 +842,16 @@ async function main() {
   setupKeyboard(app);
   document.getElementById("help").textContent = HELP_TEXT;
   document.getElementById("reset-button").onclick = () => app.reset();
+
+  // WebXR: three's button (bottom center of the page) says "VR NOT
+  // SUPPORTED" / "WEBXR NEEDS HTTPS" itself where a session cannot start.
+  document.body.appendChild(VRButton.createButton(app.renderer));
+  const calibration = document.getElementById("calibration");
+  calibration.onchange = () => {
+    app.calibrationEnabled = calibration.checked;
+    // Takes effect with the next session, like --calibration at startup;
+    // the running one keeps the state it started with.
+  };
   app.run();
 }
 main();

--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test test-ik.mjs test-teleop.mjs test-scenes.mjs",
+    "test": "node --test test-ik.mjs test-teleop.mjs test-scenes.mjs test-xr.mjs",
     "test:browser": "playwright test",
     "serve": "node serve.mjs"
   },

--- a/web/serve.mjs
+++ b/web/serve.mjs
@@ -17,11 +17,19 @@ import fs from "node:fs/promises";
 // for `python3 -m http.server` with no dependencies. Serves the repository
 // root (one level above web/) so the top-level index.html, web/*.js, and the
 // v2/ model files are all reachable. Run with: node serve.mjs [port]
+//
+// WebXR only runs on an HTTPS page (or on localhost), so a headset on the
+// LAN needs TLS: set TLS_CERTIFICATE_FILE and TLS_KEY_FILE (the same
+// variables dora-openarm-webxr uses) to serve HTTPS instead.
 import http from "node:http";
+import https from "node:https";
+import os from "node:os";
 import path from "node:path";
 
 const ROOT = path.resolve(import.meta.dirname, "..");
 const PORT = Number(process.argv[2] ?? process.env.PORT ?? 8080);
+const TLS_CERTIFICATE_FILE = process.env.TLS_CERTIFICATE_FILE;
+const TLS_KEY_FILE = process.env.TLS_KEY_FILE;
 
 // Module scripts are MIME-checked by browsers, so .js/.mjs must be
 // text/javascript. Everything else here is served for completeness; fetch()
@@ -41,7 +49,7 @@ const MIME = {
   ".md": "text/markdown; charset=utf-8",
 };
 
-const server = http.createServer(async (req, res) => {
+const handler = async (req, res) => {
   const url = new URL(req.url, "http://localhost");
   let filePath = path.normalize(
     path.join(ROOT, decodeURIComponent(url.pathname)),
@@ -65,8 +73,30 @@ const server = http.createServer(async (req, res) => {
   } catch {
     res.writeHead(404).end("Not Found");
   }
-});
+};
+
+let server;
+let scheme = "http";
+if (TLS_CERTIFICATE_FILE || TLS_KEY_FILE) {
+  if (!TLS_CERTIFICATE_FILE || !TLS_KEY_FILE) {
+    console.error("TLS_CERTIFICATE_FILE and TLS_KEY_FILE must be set together");
+    process.exit(1);
+  }
+  server = https.createServer(
+    {
+      cert: await fs.readFile(TLS_CERTIFICATE_FILE),
+      key: await fs.readFile(TLS_KEY_FILE),
+    },
+    handler,
+  );
+  scheme = "https";
+} else {
+  server = http.createServer(handler);
+}
 
 server.listen(PORT, () => {
-  console.log(`Serving ${ROOT} at http://localhost:${PORT}/`);
+  console.log(`Serving ${ROOT} at ${scheme}://localhost:${PORT}/`);
+  if (scheme === "https") {
+    console.log(`  from another device: ${scheme}://${os.hostname()}:${PORT}/`);
+  }
 });

--- a/web/test-xr.mjs
+++ b/web/test-xr.mjs
@@ -1,0 +1,555 @@
+// Copyright 2026 Enactic, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import assert from "node:assert/strict";
+// Headless tests of the WebXR teleoperation pipeline ported from
+// dora-openarm-webxr: frame reading (xr-frame.js), the controller pose to
+// arm_origin-frame mapping, smoothing and world placement (xr-pose.js), and
+// the neck pivot calibration (calibration.js).
+// Run with: node --test test-xr.mjs
+import { describe, it } from "node:test";
+import {
+  calibratePivot,
+  fitPivotOffset,
+  PivotCalibration,
+  symmetricEigen3,
+} from "./calibration.js";
+import {
+  eulerZYXToQuat,
+  poseWorldToLocal,
+  quatError,
+  quatMul,
+  quatRotVec,
+} from "./ik.js";
+import { DEFAULT_HOME, TeleopState } from "./teleop.js";
+import { readFrame } from "./xr-frame.js";
+import {
+  adjustPose,
+  CONTROLLER_TO_EE,
+  DEFAULT_FRAME_OFFSET,
+  DEFAULT_NECK_PIVOT_OFFSET,
+  HEAD_OFFSET,
+  headAnchor,
+  OneEuroPoseSmoother,
+  ROBOT_ROTATION,
+  robotPoseToXR,
+  robotToXR,
+  worldPlacement,
+  XRTeleop,
+} from "./xr-pose.js";
+
+const near = (a, b, tol) => Math.abs(a - b) < tol;
+const nearVec = (a, b, tol, what = "") =>
+  assert.ok(
+    a.length === b.length && a.every((v, i) => near(v, b[i], tol)),
+    `${what} ${a.map((v) => v.toFixed(4))} != ${b.map((v) => v.toFixed(4))}`,
+  );
+// Rotation error between two quaternions, in radians (q and -q agree).
+const rotError = (a, b) => Math.hypot(...quatError(a, b));
+
+const CONFIG = {
+  frameOffset: DEFAULT_FRAME_OFFSET,
+  neckPivotOffset: DEFAULT_NECK_PIVOT_OFFSET,
+};
+const IDENTITY = { x: 0, y: 0, z: 0, qx: 0, qy: 0, qz: 0, qw: 1 };
+// WebXR pose object from a position and a [w, x, y, z] quaternion.
+const xr = (pos, quat = [1, 0, 0, 0]) => ({
+  x: pos[0],
+  y: pos[1],
+  z: pos[2],
+  qw: quat[0],
+  qx: quat[1],
+  qy: quat[2],
+  qz: quat[3],
+});
+const HOME_QUAT = eulerZYXToQuat(0, -Math.PI / 2, 0);
+
+describe("controller pose mapping (main.py: _adjust_pose)", () => {
+  it("ROBOT_ROTATION takes WebXR forward/right/up to robot x/-y/z", () => {
+    nearVec(quatRotVec(ROBOT_ROTATION, [0, 0, -1]), [1, 0, 0], 1e-12, "fwd");
+    nearVec(quatRotVec(ROBOT_ROTATION, [1, 0, 0]), [0, -1, 0], 1e-12, "right");
+    nearVec(quatRotVec(ROBOT_ROTATION, [0, 1, 0]), [0, 0, 1], 1e-12, "up");
+  });
+
+  it("a hand at the neck pivot lands on the frame offset", () => {
+    const pivot = DEFAULT_NECK_PIVOT_OFFSET; // identity headset at the origin
+    const { pos } = adjustPose(xr(pivot), IDENTITY, CONFIG);
+    nearVec(pos, DEFAULT_FRAME_OFFSET, 1e-12);
+  });
+
+  it("a level controller pointing forward gives the home orientation", () => {
+    // The keyboard home pose (rpy 0 -90 0 in the arm_origin frame) is what
+    // dora-openarm-keyboard and the scene keyframes agree on; the aim pose
+    // of a controller held straight ahead must map onto it.
+    const { quat } = adjustPose(IDENTITY, IDENTITY, CONFIG);
+    assert.ok(rotError(quat, HOME_QUAT) < 1e-9, `quat ${quat}`);
+    nearVec(quat, quatMul(ROBOT_ROTATION, CONTROLLER_TO_EE), 1e-12);
+  });
+
+  it("robotToXR and robotPoseToXR invert the mapping", () => {
+    const reference = xr([0.1, 1.6, -0.2], eulerZYXToQuat(0.1, -0.2, 0.3));
+    const target = eulerZYXToQuat(0.2, -1.4, 0.1);
+    for (const side of ["left", "right"]) {
+      const p = robotToXR(DEFAULT_HOME[side], reference, CONFIG);
+      const { pos } = adjustPose(xr(p), reference, CONFIG);
+      nearVec(pos, DEFAULT_HOME[side], 1e-12, side);
+      const hand = robotPoseToXR(DEFAULT_HOME[side], target, reference, CONFIG);
+      const back = adjustPose(hand, reference, CONFIG);
+      nearVec(back.pos, DEFAULT_HOME[side], 1e-12, side);
+      assert.ok(rotError(back.quat, target) < 1e-9, `${side} orientation`);
+    }
+  });
+
+  it("the home pose is in front of the chest, hands 30 cm apart", () => {
+    const left = robotToXR(DEFAULT_HOME.left, IDENTITY, CONFIG);
+    const right = robotToXR(DEFAULT_HOME.right, IDENTITY, CONFIG);
+    assert.ok(left[0] < 0 && right[0] > 0, "left hand on the left");
+    assert.ok(near(right[0] - left[0], 0.307, 1e-9));
+    assert.ok(left[1] < 0, "below the eyes");
+    assert.ok(left[2] < -0.2, "in front");
+  });
+
+  it("turning the head about the neck pivot leaves the target put", () => {
+    // The headset orbits the pivot: for a head rotation q the headset is at
+    // pivot - q * offset. With the right offset configured, the target of a
+    // stationary hand must not move; with [0, 0, 0] (plain headset
+    // subtraction) it drags along the arc.
+    const pivotWorld = [0, 1.5, 0];
+    const hand = xr([0.2, 1.2, -0.4]);
+    // WebXR is y-up: a head turn (yaw) is about y, a nod (pitch) about x.
+    const headset = (yaw, pitch, offset) => {
+      const q = eulerZYXToQuat(pitch, yaw, 0);
+      const swung = quatRotVec(q, offset);
+      return xr(
+        pivotWorld.map((v, i) => v - swung[i]),
+        q,
+      );
+    };
+    const offset = [0.004, -0.081, 0.076];
+    const config = { ...CONFIG, neckPivotOffset: offset };
+    const still = adjustPose(hand, headset(0, 0, offset), config).pos;
+    const turned = adjustPose(hand, headset(0.6, -0.3, offset), config).pos;
+    nearVec(turned, still, 1e-12, "with the pivot");
+
+    const plain = { ...CONFIG, neckPivotOffset: [0, 0, 0] };
+    const dragged = adjustPose(hand, headset(0.6, 0, offset), plain).pos;
+    assert.ok(
+      Math.hypot(...dragged.map((v, i) => v - still[i])) > 0.03,
+      "plain headset subtraction reads the arc as motion",
+    );
+  });
+});
+
+describe("worldPlacement", () => {
+  it("draws a MuJoCo world point where robotToXR puts its target", () => {
+    const origin = {
+      pos: [0.3, 0.1, 1.15],
+      quat: eulerZYXToQuat(0, 0, 0.4),
+    };
+    const reference = xr([0.05, 1.6, 0.1], eulerZYXToQuat(0, 0.1, -0.2));
+    const { pos, quat } = worldPlacement(origin, reference, CONFIG);
+    for (const m of [
+      [0, 0, 0],
+      [0.5, -0.2, 0.9],
+      [-1, 1, 2],
+    ]) {
+      const placed = quatRotVec(quat, m).map((v, i) => v + pos[i]);
+      const local = poseWorldToLocal(origin, m, [1, 0, 0, 0]);
+      nearVec(placed, robotToXR(local.pos, reference, CONFIG), 1e-9, `${m}`);
+    }
+  });
+
+  it("draws the anchor's world point at its WebXR point", () => {
+    const origin = { pos: [0.185, 0, 1.34], quat: [1, 0, 0, 0] };
+    const reference = xr([0.1, 1.5, -0.3], eulerZYXToQuat(0, 0.2, 0));
+    const anchor = { world: [0.245, 0, 1.8], xr: [0.1, 1.5, -0.3] };
+    const { pos, quat } = worldPlacement(origin, reference, CONFIG, anchor);
+    const placed = quatRotVec(quat, anchor.world).map((v, i) => v + pos[i]);
+    nearVec(placed, anchor.xr, 1e-12, "camera at the headset");
+    // same rotation as without the anchor
+    const plain = worldPlacement(origin, reference, CONFIG);
+    nearVec(quat, plain.quat, 1e-12, "rotation");
+  });
+
+  it("headAnchor puts the head position at the headset", () => {
+    const origin = { pos: [0.185, 0, 1.34], quat: eulerZYXToQuat(0, 0, 0.3) };
+    const reference = xr([0.1, 1.5, -0.3], eulerZYXToQuat(0, 0.2, 0));
+    const anchor = headAnchor(origin, reference);
+    const expected = origin.pos.map(
+      (v, i) => v + quatRotVec(origin.quat, HEAD_OFFSET)[i],
+    );
+    nearVec(anchor.world, expected, 1e-12, "head in the world");
+    nearVec(anchor.xr, [0.1, 1.5, -0.3], 1e-12, "at the headset");
+    const { pos, quat } = worldPlacement(origin, reference, CONFIG, anchor);
+    const placed = quatRotVec(quat, anchor.world).map((v, i) => v + pos[i]);
+    nearVec(placed, anchor.xr, 1e-12, "placed");
+    // the arm base is below the eyes and a little behind them
+    const base = quatRotVec(quat, origin.pos).map((v, i) => v + pos[i]);
+    assert.ok(base[1] < anchor.xr[1] - 0.2, "below");
+  });
+
+  it("turns MuJoCo z-up into WebXR y-up", () => {
+    const origin = { pos: [0, 0, 0], quat: [1, 0, 0, 0] };
+    const { quat } = worldPlacement(origin, IDENTITY, CONFIG);
+    nearVec(quatRotVec(quat, [0, 0, 1]), [0, 1, 0], 1e-12, "up");
+    nearVec(quatRotVec(quat, [1, 0, 0]), [0, 0, -1], 1e-12, "forward");
+  });
+});
+
+describe("OneEuroPoseSmoother (smoothing.py)", () => {
+  it("passes the first sample and a non-advancing clock through", () => {
+    const s = new OneEuroPoseSmoother();
+    const pose = [1, 2, 3, 1, 0, 0, 0];
+    assert.deepEqual(s.smooth(0, pose), pose);
+    assert.deepEqual(s.smooth(0, [4, 5, 6, 1, 0, 0, 0]), [4, 5, 6, 1, 0, 0, 0]);
+  });
+
+  it("lags a step and converges to it, quaternion kept unit", () => {
+    const s = new OneEuroPoseSmoother({
+      minCutoff: 2,
+      beta: 0.04,
+      dCutoff: 1.5,
+    });
+    const q1 = eulerZYXToQuat(0, 0, 1.0);
+    s.smooth(0, [0, 0, 0, 1, 0, 0, 0]);
+    const first = s.smooth(1 / 72, [1, 0, 0, ...q1]);
+    assert.ok(first[0] > 0 && first[0] < 1, `lags: ${first[0]}`);
+    assert.ok(near(Math.hypot(...first.slice(3)), 1, 1e-9), "unit quat");
+    let last = first;
+    for (let i = 2; i <= 72; i++) last = s.smooth(i / 72, [1, 0, 0, ...q1]);
+    assert.ok(near(last[0], 1, 1e-3), `converged: ${last[0]}`);
+    assert.ok(rotError(last.slice(3), q1) < 1e-2, "rotation converged");
+  });
+
+  it("smooths more slowly at low speed than at high speed", () => {
+    const step = (speed) => {
+      const s = new OneEuroPoseSmoother({ minCutoff: 1, beta: 1, dCutoff: 1 });
+      s.smooth(0, [0, 0, 0, 1, 0, 0, 0]);
+      s.smooth(0.01, [speed * 0.01, 0, 0, 1, 0, 0, 0]);
+      const out = s.smooth(0.02, [speed * 0.02, 0, 0, 1, 0, 0, 0]);
+      return out[0] / (speed * 0.02); // fraction of the input reached
+    };
+    assert.ok(step(10) > step(0.1), "adaptive cutoff");
+  });
+});
+
+describe("symmetricEigen3", () => {
+  it("decomposes a symmetric matrix", () => {
+    const A = [4, 1, 2, 1, 3, 0, 2, 0, 5];
+    const { values, vectors } = symmetricEigen3(A);
+    assert.ok(values[0] <= values[1] && values[1] <= values[2], "ascending");
+    for (let k = 0; k < 3; k++) {
+      const v = vectors[k];
+      assert.ok(near(Math.hypot(...v), 1, 1e-9), "unit");
+      const Av = [0, 1, 2].map(
+        (i) => A[i * 3] * v[0] + A[i * 3 + 1] * v[1] + A[i * 3 + 2] * v[2],
+      );
+      nearVec(
+        Av,
+        v.map((x) => x * values[k]),
+        1e-9,
+        `eigenpair ${k}`,
+      );
+    }
+    assert.ok(near(values[0] + values[1] + values[2], 12, 1e-9), "trace");
+  });
+});
+
+// A calibration run: the headset orbits a fixed pivot, at `offset` in its
+// own frame, through the given yaw (about WebXR's y) and pitch (about x)
+// sweeps in radians, optionally with the body drifting.
+function headsetRun(offset, { yaw = 0.45, pitch = 0.45, drift = 0, n = 400 }) {
+  const pivotWorld = [0, 1.5, 0];
+  const samples = [];
+  for (let i = 0; i < n; i++) {
+    const t = i / n;
+    const phase = 2 * Math.PI * 2 * t; // two sweeps of each over the run
+    const y = t < 0.5 ? yaw * Math.sin(2 * phase) : 0;
+    const p = t >= 0.5 ? pitch * Math.sin(2 * phase) : 0;
+    const q = eulerZYXToQuat(p, y, 0);
+    const swung = quatRotVec(q, offset);
+    const pos = pivotWorld.map((v, k) => v - swung[k] + drift * t * (k === 0));
+    samples.push({ pos, quat: q });
+  }
+  return samples;
+}
+
+describe("neck pivot calibration (calibration.py + main.py policy)", () => {
+  const offset = [0.004, -0.081, 0.076];
+
+  it("recovers the offset from a side-to-side and up-and-down run", () => {
+    const run = headsetRun(offset, {});
+    const { offset: fitted, diagnostics } = fitPivotOffset(
+      run.map((s) => s.pos),
+      run.map((s) => s.quat),
+    );
+    nearVec(fitted, offset, 1e-6);
+    assert.ok(diagnostics.residualRms < 1e-6, "pivot held still");
+    assert.ok(diagnostics.headsetRms > 0.02, "headset moved");
+    assert.ok(diagnostics.observability[0] > 0.02, "all axes observed");
+    const result = calibratePivot(run);
+    assert.equal(result.accepted, true, result.reason);
+    nearVec(result.offset, offset, 1e-6);
+    assert.equal(result.samples, 400);
+  });
+
+  it("rejects a tap", () => {
+    const result = calibratePivot(headsetRun(offset, { n: 20 }));
+    assert.equal(result.accepted, false);
+    assert.match(result.reason, /only 20 headset poses/);
+  });
+
+  it("rejects a yaw-only run and asks for the nod that pins the vertical offset", () => {
+    const result = calibratePivot(headsetRun(offset, { pitch: 0 }));
+    assert.equal(result.accepted, false);
+    assert.match(result.reason, /vertical offset; turn it up and down/);
+  });
+
+  it("rejects a run where the body moved", () => {
+    const result = calibratePivot(headsetRun(offset, { drift: 0.2 }));
+    assert.equal(result.accepted, false);
+    assert.match(result.reason, /hold the body still/);
+  });
+
+  it("rejects a pivot that is not where a neck is", () => {
+    const result = calibratePivot(headsetRun([0, 0.1, -0.05], {}));
+    assert.equal(result.accepted, false);
+    assert.match(result.reason, /not where a neck is/);
+  });
+
+  it("PivotCalibration collects for the length of the press, when enabled", () => {
+    const off = new PivotCalibration({ enabled: false });
+    assert.equal(off.update(true), null);
+    assert.equal(off.collecting, false, "disabled: never collects");
+    off.add(IDENTITY);
+    assert.equal(off.update(false), null);
+
+    const on = new PivotCalibration({ enabled: true, capacity: 3 });
+    assert.equal(on.update(false), null, "nothing to fit before a press");
+    assert.equal(on.update(true), null);
+    assert.equal(on.collecting, true);
+    for (let i = 0; i < 5; i++) on.add(xr([i, 0, 0]));
+    assert.equal(on.update(true), null, "still held");
+    const run = on.update(false);
+    assert.equal(run.length, 3, "capacity keeps the newest");
+    assert.deepEqual(
+      run.map((s) => s.pos[0]),
+      [2, 3, 4],
+    );
+    assert.equal(on.collecting, false);
+    assert.equal(on.update(false), null, "a release is one run");
+  });
+});
+
+// The frame object xr-frame.js builds, from plain values.
+function frame({ reference = IDENTITY, right, left, triggers = {} } = {}) {
+  const f = { pose_reference: reference };
+  if (right) f.pose_right = right;
+  if (left) f.pose_left = left;
+  for (const [side, v] of Object.entries(triggers)) f[`trigger_${side}`] = v;
+  return f;
+}
+
+describe("XRTeleop.processFrame (main.py: _process_frame)", () => {
+  it("writes the controller poses and triggers into the teleop targets", () => {
+    const teleop = new TeleopState();
+    const t = new XRTeleop();
+    const rightXR = robotToXR([0.3, -0.1, -0.2], IDENTITY, CONFIG);
+    const updated = t.processFrame(
+      frame({ right: xr(rightXR), triggers: { right: 0.3 } }),
+      0,
+      teleop,
+    );
+    assert.deepEqual(updated, ["right"]);
+    nearVec(teleop.arms.right.pos, [0.3, -0.1, -0.2], 1e-12);
+    assert.ok(rotError(teleop.arms.right.quat, HOME_QUAT) < 1e-9);
+    assert.equal(teleop.arms.right.grip, 0.3);
+    nearVec(teleop.arms.left.pos, DEFAULT_HOME.left, 1e-12, "left untouched");
+  });
+
+  it("needs the headset pose and the trigger to move a hand", () => {
+    const teleop = new TeleopState();
+    const t = new XRTeleop();
+    const f = frame({ right: xr([0, 0, -0.5]), triggers: { right: 0 } });
+    f.pose_reference = undefined;
+    assert.deepEqual(t.processFrame(f, 0, teleop), []);
+    assert.deepEqual(
+      t.processFrame(frame({ right: xr([0, 0, -0.5]) }), 0, teleop),
+      [],
+    );
+    nearVec(teleop.arms.right.pos, DEFAULT_HOME.right, 1e-12);
+  });
+
+  it("smooths across frames", () => {
+    const teleop = new TeleopState();
+    const t = new XRTeleop();
+    const a = robotToXR([0.2, -0.15, -0.2], IDENTITY, CONFIG);
+    const b = robotToXR([0.3, -0.15, -0.2], IDENTITY, CONFIG);
+    t.processFrame(frame({ right: xr(a), triggers: { right: 0 } }), 0, teleop);
+    t.processFrame(
+      frame({ right: xr(b), triggers: { right: 0 } }),
+      1 / 72,
+      teleop,
+    );
+    const x = teleop.arms.right.pos[0];
+    assert.ok(x > 0.2 && x < 0.3, `between the samples: ${x}`);
+  });
+
+  it("stops the hands during a calibration run and applies the result", () => {
+    const teleop = new TeleopState();
+    const results = [];
+    const t = new XRTeleop({
+      calibration: true,
+      onCalibrationResult: (r) => results.push(r),
+    });
+    const hand = xr(robotToXR([0.3, -0.1, -0.2], IDENTITY, CONFIG));
+    t.processFrame(frame({ right: hand, triggers: { right: 0 } }), 0, teleop);
+    const before = [...teleop.arms.right.pos];
+
+    const offset = [0.004, -0.081, 0.076];
+    const run = headsetRun(offset, {});
+    run.forEach((s, i) => {
+      const f = frame({
+        reference: xr(s.pos, s.quat),
+        right: xr([0.5, 0.5, 0.5]),
+        triggers: { right: 0 },
+      });
+      f.button_y = true;
+      assert.deepEqual(t.processFrame(f, (i + 1) / 72, teleop), []);
+    });
+    nearVec(teleop.arms.right.pos, before, 1e-12, "hands held");
+    assert.equal(results.length, 0, "not fitted until the release");
+
+    // release: fitted, accepted and in use from this frame on
+    const updated = t.processFrame(
+      frame({ right: hand, triggers: { right: 0 } }),
+      10,
+      teleop,
+    );
+    assert.equal(results.length, 1);
+    assert.equal(results[0].accepted, true, results[0].reason);
+    nearVec(t.neckPivotOffset, offset, 1e-6);
+    assert.deepEqual(updated, ["right"]);
+  });
+
+  it("without calibration the Y button is an ordinary button", () => {
+    const teleop = new TeleopState();
+    const t = new XRTeleop();
+    const f = frame({ right: xr([0, 0, -0.5]), triggers: { right: 0 } });
+    f.button_y = true;
+    assert.deepEqual(t.processFrame(f, 0, teleop), ["right"]);
+    f.button_y = false;
+    assert.deepEqual(t.processFrame(f, 1, teleop), ["right"]);
+  });
+});
+
+// Fakes for the WebXR objects readFrame touches.
+function fakeSource(handedness, { profiles, buttons, axes, pose }) {
+  return {
+    handedness,
+    profiles,
+    targetRaySpace: { pose },
+    gamepad: buttons ? { buttons, axes: axes ?? [] } : null,
+  };
+}
+const fakeFrame = (viewer) => ({
+  getViewerPose: () => viewer && { transform: viewer },
+  getPose: (space) => space.pose && { transform: space.pose },
+});
+const transform = (pos, quat = [1, 0, 0, 0]) => ({
+  position: { x: pos[0], y: pos[1], z: pos[2] },
+  orientation: { x: quat[1], y: quat[2], z: quat[3], w: quat[0] },
+});
+const button = (value, pressed = value > 0.5) => ({ value, pressed });
+
+describe("readFrame (ar.js: sendFrame)", () => {
+  const quest = ["meta-quest-touch-plus", "generic-trigger-squeeze-thumbstick"];
+
+  it("reads the headset, both controllers, triggers, buttons and sticks", () => {
+    const session = {
+      inputSources: [
+        fakeSource("left", {
+          profiles: quest,
+          pose: transform([-0.2, 1.2, -0.4]),
+          buttons: [
+            button(0.25),
+            button(0),
+            button(0),
+            button(0),
+            button(0),
+            button(1),
+          ],
+          axes: [0, 0, 0.5, -0.25],
+        }),
+        fakeSource("right", {
+          profiles: quest,
+          pose: transform([0.2, 1.2, -0.4], HOME_QUAT),
+          buttons: [
+            button(1),
+            button(0.5),
+            button(0),
+            button(0),
+            button(1),
+            button(0),
+          ],
+          axes: [0, 0, 0, 0],
+        }),
+      ],
+    };
+    const r = readFrame(session, {}, fakeFrame(transform([0, 1.6, 0])));
+    assert.deepEqual(r.pose_reference, {
+      ...IDENTITY,
+      y: 1.6,
+    });
+    assert.equal(r.pose_left.x, -0.2);
+    assert.ok(near(r.pose_right.qy, HOME_QUAT[2], 1e-12), "orientation xyzw");
+    assert.equal(r.trigger_left, 0.25);
+    assert.equal(r.trigger_right, 1);
+    assert.equal(r.grip_right, 0.5);
+    assert.equal(r.button_x, false);
+    assert.equal(r.button_y, true);
+    assert.equal(r.button_a, true);
+    assert.equal(r.button_b, false);
+    assert.deepEqual(r.joystick_left, [0, 0, 0.5, -0.25]);
+  });
+
+  it("with one controller only the headset is read", () => {
+    const session = {
+      inputSources: [
+        fakeSource("right", {
+          profiles: quest,
+          pose: transform([0, 0, 0]),
+          buttons: [button(1)],
+        }),
+      ],
+    };
+    const r = readFrame(session, {}, fakeFrame(transform([0, 1.6, 0])));
+    assert.deepEqual(Object.keys(r), ["pose_reference"]);
+  });
+
+  it("an unknown profile gives its pose but no trigger, and no headset gives nothing", () => {
+    const session = {
+      inputSources: [
+        fakeSource("left", {
+          profiles: ["some-other-controller"],
+          pose: transform([0, 0, 0]),
+          buttons: [button(1)],
+        }),
+        fakeSource("none", { profiles: quest, pose: transform([0, 0, 0]) }),
+      ],
+    };
+    const r = readFrame(session, {}, fakeFrame(null));
+    assert.deepEqual(Object.keys(r), ["pose_left"]);
+  });
+});

--- a/web/xr-frame.js
+++ b/web/xr-frame.js
@@ -1,0 +1,77 @@
+// Copyright 2026 Enactic, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Read one WebXR frame into the frame object dora-openarm-webxr's client
+// sends to its node (static/ar.js: sendFrame), so that xr-pose.js can be a
+// port of the node: { pose_reference, pose_left, pose_right, trigger_*,
+// grip_*, joystick_*, button_* }, poses as {x, y, z, qx, qy, qz, qw}.
+
+// The controller profiles whose xr-standard gamepad layout is known:
+// buttons[0] trigger, [1] squeeze, [4]/[5] A/B on the right hand and X/Y on
+// the left.
+const KNOWN_PROFILES = ["pico-4u", "meta-quest-touch-plus", "oculus-touch-v3"];
+
+function xrTransform(transform) {
+  return {
+    x: transform.position.x,
+    y: transform.position.y,
+    z: transform.position.z,
+    qx: transform.orientation.x,
+    qy: transform.orientation.y,
+    qz: transform.orientation.z,
+    qw: transform.orientation.w,
+  };
+}
+
+export function readFrame(session, space, frame) {
+  const response = {};
+  // Read before the controller check below: the hand poses are made relative
+  // to this pose, so when it is missing the hands are dropped.
+  const viewerPose = frame.getViewerPose(space);
+  if (viewerPose) response.pose_reference = xrTransform(viewerPose.transform);
+  if (session.inputSources.length < 2) return response;
+  for (const source of session.inputSources) {
+    if (source.handedness === "none") continue;
+    const suffix = `_${source.handedness}`;
+    // The target ray space is the OpenXR aim pose: its -Z points where the
+    // controller points, which xr-pose.js maps onto the gripper axis. Not
+    // the grip pose, whose -Z runs along the handle and would turn the
+    // handle's tilt into the gripper's.
+    const pose = frame.getPose(source.targetRaySpace, space);
+    if (pose) response[`pose${suffix}`] = xrTransform(pose.transform);
+    const gamepad = source.gamepad;
+    if (!gamepad) continue;
+    if (source.profiles.some((p) => KNOWN_PROFILES.includes(p))) {
+      response[`trigger${suffix}`] = gamepad.buttons[0].value;
+      // Sent as its 0..1 value rather than a pressed flag, so that a
+      // consumer can pick its own threshold.
+      const grip = gamepad.buttons[1];
+      if (grip) response[`grip${suffix}`] = grip.value;
+      if (source.handedness === "right") {
+        response.button_a = gamepad.buttons[4].pressed;
+        response.button_b = gamepad.buttons[5].pressed;
+      } else {
+        response.button_x = gamepad.buttons[4].pressed;
+        response.button_y = gamepad.buttons[5].pressed;
+      }
+    }
+    // The whole array: the xr-standard mapping reserves the first axis
+    // pair for the touchpad and the second for the thumbstick, and a
+    // centred stick reads exactly 0, so no truthiness check here.
+    if (gamepad.axes.length >= 2) {
+      response[`joystick${suffix}`] = Array.from(gamepad.axes);
+    }
+  }
+  return response;
+}

--- a/web/xr-hud.js
+++ b/web/xr-hud.js
@@ -1,0 +1,71 @@
+// Copyright 2026 Enactic, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A text panel for the headset: the page's status element is out of sight
+// in an immersive session, so the same lines (and the calibration
+// instructions and results, which dora-openarm-webxr draws on its own panel)
+// are drawn onto a canvas texture on a plane that hangs below the view.
+import * as THREE from "three";
+
+const WIDTH = 1024;
+const HEIGHT = 320;
+const LINE_HEIGHT = 34;
+
+export class XRHud {
+  constructor() {
+    this.canvas = document.createElement("canvas");
+    this.canvas.width = WIDTH;
+    this.canvas.height = HEIGHT;
+    this.texture = new THREE.CanvasTexture(this.canvas);
+    this.texture.colorSpace = THREE.NoColorSpace;
+    const material = new THREE.MeshBasicMaterial({
+      map: this.texture,
+      transparent: true,
+      depthTest: false,
+      depthWrite: false,
+    });
+    // 0.8 m wide, a meter ahead and a bit below eye level: readable
+    // without being in the way of the arms.
+    this.mesh = new THREE.Mesh(
+      new THREE.PlaneGeometry(0.8, (0.8 * HEIGHT) / WIDTH),
+      material,
+    );
+    this.mesh.position.set(0, -0.35, -1);
+    this.mesh.renderOrder = 1000;
+    this.mesh.visible = false;
+    this.text = null;
+  }
+
+  setText(text) {
+    if (text === this.text) return;
+    this.text = text;
+    const ctx = this.canvas.getContext("2d");
+    ctx.clearRect(0, 0, WIDTH, HEIGHT);
+    ctx.fillStyle = "rgba(0, 0, 0, 0.55)";
+    ctx.fillRect(0, 0, WIDTH, HEIGHT);
+    ctx.fillStyle = "#ffffff";
+    ctx.font = "26px monospace";
+    ctx.textBaseline = "top";
+    text.split("\n").forEach((line, i) => {
+      ctx.fillText(line, 20, 16 + i * LINE_HEIGHT);
+    });
+    this.texture.needsUpdate = true;
+  }
+
+  dispose() {
+    this.texture.dispose();
+    this.mesh.material.dispose();
+    this.mesh.geometry.dispose();
+  }
+}

--- a/web/xr-pose.js
+++ b/web/xr-pose.js
@@ -1,0 +1,292 @@
+// Copyright 2026 Enactic, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// WebXR controller poses to arm_origin-frame pose targets, ported from
+// dora-openarm-webxr (src/dora_openarm_webxr/main.py and smoothing.py).
+//
+// There the browser sends every WebXR frame to a Python node that converts
+// the controller pose into the OpenArm workspace, smooths it with a One Euro
+// filter and publishes it for the IK downstream. Here the page is the whole
+// pipeline, so that conversion runs in the browser and feeds TeleopState
+// (teleop.js) directly: XRTeleop.processFrame() takes the same frame object
+// the dora client sends (see xr-frame.js) and overwrites the teleop targets
+// with the controller poses.
+//
+// Quaternions are [w, x, y, z] like the rest of this app (ik.js); WebXR's
+// {x, y, z, w} orientation is converted on the way in.
+import { calibratePivot, PivotCalibration } from "./calibration.js";
+import { mat2quat, quatConj, quatMul, quatRotVec } from "./ik.js";
+import { LEFT, RIGHT } from "./keymap.js";
+
+// Relative pose to robot workspace mapping (main.py: _ROBOT_ROTATION). WebXR
+// is x right, y up, -z forward; the robot is x forward, y left, z up.
+export const ROBOT_ROTATION = mat2quat([0, 0, -1, -1, 0, 0, 0, 1, 0]);
+
+// Neutral hand position relative to the arm_origin site (chest level):
+// main.py's _FRAME_OFFSET_CELL.
+export const DEFAULT_FRAME_OFFSET = [-0.085, 0, -0.14];
+
+// The controller is read from the WebXR target ray space, the OpenXR aim
+// pose whose -Z points where the controller points. This turn maps that aim
+// frame onto the end effector one, which points the gripper along its own -z
+// and opens it across y (main.py: _CONTROLLER_TO_EE, z +90 degrees).
+export const CONTROLLER_TO_EE = [Math.SQRT1_2, 0, 0, Math.SQRT1_2];
+
+// Eyes to the neck's rotation axis, in the headset's own frame (-Z forward,
+// +Y up: below and behind the face). The head turns about the neck, not the
+// headset, so subtracting the headset position alone would read every head
+// turn as the operator translating and drag the target along the arc the
+// headset travels. An estimate that anatomy varies: measure it with the
+// neck pivot calibration (calibration.js). [0, 0, 0] is the plain headset
+// subtraction (main.py: _NECK_PIVOT_OFFSET).
+export const DEFAULT_NECK_PIVOT_OFFSET = [0.0, -0.075, 0.08];
+
+// Where the operator's eyes go relative to the arm_origin site, in its
+// frame (x forward, z up), when the world is placed for a headset. OpenArm
+// has no head, so this is a human one: the eyes sit some 22 cm above the
+// shoulder joints and a little ahead of them.
+export const HEAD_OFFSET = [0.03, 0, 0.22];
+
+// One Euro filter parameters main.py builds its per-hand smoothers with.
+const SMOOTHER_OPTIONS = { minCutoff: 2.0, beta: 0.04, dCutoff: 1.5 };
+
+export const SIDES = [LEFT, RIGHT];
+
+// WebXR {x, y, z, qx, qy, qz, qw} -> position and [w, x, y, z] quaternion.
+export function xrPose(p) {
+  return { pos: [p.x, p.y, p.z], quat: [p.qw, p.qx, p.qy, p.qz] };
+}
+
+function slerp(q1, q2, alpha) {
+  let dot = q1[0] * q2[0] + q1[1] * q2[1] + q1[2] * q2[2] + q1[3] * q2[3];
+  let b = q2;
+  if (dot < 0) {
+    b = q2.map((v) => -v);
+    dot = -dot;
+  }
+  if (dot > 0.9995) {
+    const res = q1.map((v, i) => v + alpha * (b[i] - v));
+    const n = Math.hypot(...res);
+    return res.map((v) => v / n);
+  }
+  const theta0 = Math.acos(dot);
+  const sinTheta0 = Math.sin(theta0);
+  const theta = theta0 * alpha;
+  const sinTheta = Math.sin(theta);
+  const s0 = Math.cos(theta) - (dot * sinTheta) / sinTheta0;
+  const s1 = sinTheta / sinTheta0;
+  return q1.map((v, i) => s0 * v + s1 * b[i]);
+}
+
+// One Euro filter applied to position (adaptive cutoff) and rotation (slerp
+// with the same alpha); port of smoothing.py's OneEuroPoseSmoother. Poses
+// are 7-vectors [x, y, z, qw, qx, qy, qz]; time is in seconds.
+export class OneEuroPoseSmoother {
+  constructor({ minCutoff = 10.0, beta = 0.8, dCutoff = 1.0 } = {}) {
+    this.minCutoff = minCutoff;
+    this.beta = beta;
+    this.dCutoff = dCutoff;
+    this.reset();
+  }
+
+  // Forget the history: the next sample starts the filter afresh.
+  reset() {
+    this.pPrev = null;
+    this.qPrev = null;
+    this.dpPrev = [0, 0, 0];
+    this.tPrev = null;
+  }
+
+  smooth(t, pose) {
+    const tp = pose.slice(0, 3);
+    const tq = pose.slice(3, 7);
+    if (this.tPrev === null || this.pPrev === null) {
+      this.pPrev = tp;
+      this.qPrev = tq;
+      this.tPrev = t;
+      return [...pose];
+    }
+    const dt = t - this.tPrev;
+    if (dt <= 0) return [...pose];
+
+    const alpha = (cutoff) => {
+      const tau = 1 / (2 * Math.PI * cutoff);
+      return 1 / (1 + tau / dt);
+    };
+    const dpRaw = tp.map((v, i) => (v - this.pPrev[i]) / dt);
+    const alphaD = alpha(this.dCutoff);
+    const dp = dpRaw.map((v, i) => alphaD * v + (1 - alphaD) * this.dpPrev[i]);
+    const cutoffP = this.minCutoff + this.beta * Math.hypot(...dp);
+    const alphaP = alpha(cutoffP);
+    const pHat = this.pPrev.map((v, i) => v + alphaP * (tp[i] - v));
+    const qHat = slerp(this.qPrev, tq, alphaP);
+
+    this.pPrev = pHat;
+    this.qPrev = qHat;
+    this.dpPrev = dp;
+    this.tPrev = t;
+    return [...pHat, ...qHat];
+  }
+}
+
+// The neck pivot in WebXR coordinates for a headset pose: behind the face,
+// wherever the head is facing.
+export function neckPivot(reference, neckPivotOffset) {
+  const ref = xrPose(reference);
+  const offset = quatRotVec(ref.quat, neckPivotOffset);
+  return ref.pos.map((v, i) => v + offset[i]);
+}
+
+// Convert a WebXR controller pose into an arm_origin-frame pose target
+// (main.py: _adjust_pose, minus the smoothing).
+//
+// `pose` and `reference` (the viewer pose) are in the same world-fixed
+// reference space. Only the position is made relative to the viewer, by
+// subtracting the neck pivot in the world axes. The viewer rotation is never
+// applied to the hand: turning the head must not move the target. It only
+// places the pivot, which says which way the operator is facing.
+export function adjustPose(pose, reference, { frameOffset, neckPivotOffset }) {
+  const pivot = neckPivot(reference, neckPivotOffset);
+  const hand = xrPose(pose);
+  const relative = hand.pos.map((v, i) => v - pivot[i]);
+  const rotated = quatRotVec(ROBOT_ROTATION, relative);
+  return {
+    pos: rotated.map((v, i) => v + frameOffset[i]),
+    quat: quatMul(ROBOT_ROTATION, quatMul(hand.quat, CONTROLLER_TO_EE)),
+  };
+}
+
+// Inverse of adjustPose for positions: where in WebXR coordinates a hand has
+// to be for its target to land on `pos` in the arm_origin frame.
+export function robotToXR(pos, reference, { frameOffset, neckPivotOffset }) {
+  const pivot = neckPivot(reference, neckPivotOffset);
+  const relative = quatRotVec(
+    quatConj(ROBOT_ROTATION),
+    pos.map((v, i) => v - frameOffset[i]),
+  );
+  return relative.map((v, i) => v + pivot[i]);
+}
+
+// Full inverse of adjustPose: the WebXR pose object ({x, y, z, qx, qy, qz,
+// qw}) of a hand whose target is `pos`, `quat` in the arm_origin frame.
+export function robotPoseToXR(pos, quat, reference, config) {
+  const [x, y, z] = robotToXR(pos, reference, config);
+  const [qw, qx, qy, qz] = quatMul(
+    quatConj(ROBOT_ROTATION),
+    quatMul(quat, quatConj(CONTROLLER_TO_EE)),
+  );
+  return { x, y, z, qx, qy, qz, qw };
+}
+
+// Where to draw the MuJoCo world in the WebXR reference space: the rigid
+// transform that takes MuJoCo world coordinates to WebXR coordinates, given
+// the world pose of the arm_origin site and the headset pose the placement
+// is anchored to.
+//
+// The rotation turns the arm_origin frame the way adjustPose turns the
+// controllers (R^T q_o^-1): z-up becomes y-up and the robot's +x is ahead
+// of the operator. The translation is fixed by one anchor point:
+//
+// * By default the arm targets coincide with the controllers. Solving
+//   adjustPose for the world, a point r in the arm_origin frame is at
+//   R^T (r - f) + pivot in WebXR, so the arm_origin site itself goes to
+//   R^T (-f) + pivot.
+// * With `anchor` ({ world, xr }), the MuJoCo world point `world` is drawn
+//   at the WebXR point `xr` instead: e.g. headAnchor, which puts the
+//   headset where the robot's head would be.
+export function worldPlacement(origin, reference, config, anchor = null) {
+  const quat = quatMul(quatConj(ROBOT_ROTATION), quatConj(origin.quat));
+  const world = anchor ? anchor.world : origin.pos;
+  const xr = anchor ? anchor.xr : robotToXR([0, 0, 0], reference, config);
+  const shifted = quatRotVec(quat, world);
+  return { pos: xr.map((v, i) => v - shifted[i]), quat };
+}
+
+// The anchor that draws the robot's head position (HEAD_OFFSET from the
+// arm_origin site) at the headset: the operator looks out from where the
+// robot's head would be, with the arms below them like their own.
+export function headAnchor(origin, reference, headOffset = HEAD_OFFSET) {
+  const offset = quatRotVec(origin.quat, headOffset);
+  return {
+    world: origin.pos.map((v, i) => v + offset[i]),
+    xr: [reference.x, reference.y, reference.z],
+  };
+}
+
+// Per-session state (main.py: _ConnectionState + _process_frame): the
+// smoothers and the calibration are stateful, so a new session gets a fresh
+// one rather than inheriting the last one's history.
+export class XRTeleop {
+  constructor({
+    frameOffset = DEFAULT_FRAME_OFFSET,
+    neckPivotOffset = DEFAULT_NECK_PIVOT_OFFSET,
+    calibration = false,
+    onCalibrationResult = null,
+  } = {}) {
+    this.frameOffset = [...frameOffset];
+    this.neckPivotOffset = [...neckPivotOffset];
+    this.onCalibrationResult = onCalibrationResult;
+    this.calibration = new PivotCalibration({ enabled: calibration });
+    this.smoothers = {};
+    for (const side of SIDES) {
+      this.smoothers[side] = new OneEuroPoseSmoother(SMOOTHER_OPTIONS);
+    }
+  }
+
+  // Take one frame (the object xr-frame.js's readFrame builds) at `time`
+  // seconds and write the controller poses into `teleop`'s arm targets.
+  // Returns which sides were updated.
+  processFrame(response, time, teleop) {
+    // An absent button is a released one, so a controller that falls asleep
+    // mid-run cannot leave the hands stopped.
+    const samples = this.calibration.update(response.button_y === true);
+    if (samples) {
+      const result = calibratePivot(samples);
+      if (result.accepted) this.neckPivotOffset = [...result.offset];
+      this.onCalibrationResult?.(result);
+    }
+    const reference = response.pose_reference;
+    if (reference) this.calibration.add(reference);
+
+    const updated = [];
+    for (const side of SIDES) {
+      const pose = response[`pose_${side}`];
+      const trigger = response[`trigger_${side}`];
+      // The hands stop while a calibration run is under way: turning the
+      // head moves the target by the very arc being measured, and the
+      // operator is shaking their head, not reaching.
+      if (
+        !pose ||
+        trigger === undefined ||
+        !reference ||
+        this.calibration.collecting
+      ) {
+        continue;
+      }
+      const adjusted = adjustPose(pose, reference, this);
+      const smoothed = this.smoothers[side].smooth(time, [
+        ...adjusted.pos,
+        ...adjusted.quat,
+      ]);
+      const arm = teleop.arms[side];
+      arm.pos = smoothed.slice(0, 3);
+      arm.quat = smoothed.slice(3, 7);
+      // Trigger 0 (released) opens the gripper, 1 closes it, like
+      // main.py's _map_trigger_to_gripper does in joint angles.
+      arm.grip = Math.min(1, Math.max(0, trigger));
+      updated.push(side);
+    }
+    return updated;
+  }
+}


### PR DESCRIPTION
Open the page in a headset's browser and press ENTER VR: the MuJoCo world is drawn around the operator and the arms follow the controllers. The processing dora-openarm-webxr does in its Python node runs in the browser here, as direct ports of that project's sources:

- xr-frame.js (static/ar.js): reads the headset pose, the controllers' target-ray poses, triggers, squeezes, sticks and buttons out of an XRFrame into the frame object the dora client sends.
- xr-pose.js (main.py, smoothing.py): converts a controller pose into an arm_origin-frame target (WebXR to robot axes, neck pivot subtraction, aim pose to gripper turn, frame offset), smooths it with the same One Euro filter and writes it into TeleopState for the IK. Also places the MuJoCo world (z-up) in the headset's reference space (y-up) with the headset where the robot's head would be (HEAD_OFFSET above arm_origin).
- calibration.js (calibration.py, main.py): the neck pivot calibration, held Y button, with the fit's 3x3 eigendecomposition done by Jacobi rotations. An accepted offset is kept in localStorage.
- xr-hud.js: a canvas-texture panel for the status lines and the calibration instructions and results, since the page's panel is out of sight in the session.

X resets the environment, B ends the session. serve.mjs serves HTTPS when TLS_CERTIFICATE_FILE and TLS_KEY_FILE are set, since WebXR needs a secure page for a headset on the LAN.

The head placement (HEAD_OFFSET) is a first guess and still needs tuning on a headset.